### PR TITLE
invoke chain.doFilter(req, resp)

### DIFF
--- a/src/main/java/com/github/adminfaces/template/session/AdminFilter.java
+++ b/src/main/java/com/github/adminfaces/template/session/AdminFilter.java
@@ -91,6 +91,7 @@ public class AdminFilter implements Filter {
     @Override
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
         if (disableFilter) {
+            chain.doFilter(req, resp);
             return;
         }
         req.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
Hi !
For some reason i have to override AdminFilter, but disabling  AdminFilter with admin.disableFilter=true  breaks request processing because if disableFilter == true, it just returns and does not call chain.doFilter
So i think even if filter is disabled, we should invoke chain.doFilter