### PR TITLE
Add new config to allow extensionless URLs in breadcrumbs, fixes #46

### DIFF
--- a/src/main/java/com/github/adminfaces/template/bean/BreadCrumbMB.java
+++ b/src/main/java/com/github/adminfaces/template/bean/BreadCrumbMB.java
@@ -51,13 +51,18 @@ public class BreadCrumbMB implements Serializable {
             return;
         }
 
-        if(!has(breadCrumb.getLink())){
-            breadCrumb.setLink(FacesContext.getCurrentInstance().getViewRoot().getViewId());
+        String link = breadCrumb.getLink();
+        if(!has(link)){
+            link = FacesContext.getCurrentInstance().getViewRoot().getViewId();
         }
 
-        if(breadCrumb.getLink() != null && !breadCrumb.getLink().contains(".")){
-            breadCrumb.setLink(breadCrumb.getLink()+"."+ Constants.DEFAULT_PAGE_FORMAT);
+        if(link != null && adminConfig.isExtensionLessUrls()) {
+            link = link.substring(0, link.lastIndexOf("."));
+        }else if(link != null && !link.contains(".")){
+            link = link + "." + Constants.DEFAULT_PAGE_FORMAT;
         }
+        breadCrumb.setLink(link);
+
         if(breadCrumbs.contains(breadCrumb)){
             breadCrumbs.remove(breadCrumb);
         }

--- a/src/main/java/com/github/adminfaces/template/config/AdminConfig.java
+++ b/src/main/java/com/github/adminfaces/template/config/AdminConfig.java
@@ -35,6 +35,7 @@ public class AdminConfig implements Serializable {
     private boolean disableFilter;
     private boolean enableRipple;
     private boolean renderBreadCrumb;
+    private boolean extensionLessUrls;
     private boolean enableSlideMenu;
     private String rippleElements;
     private String skin;
@@ -77,6 +78,7 @@ public class AdminConfig implements Serializable {
         disableFilter = Boolean.parseBoolean(getProperty("admin.disableFilter"));
         enableRipple = Boolean.parseBoolean(getProperty("admin.enableRipple"));
         renderBreadCrumb = Boolean.parseBoolean(getProperty("admin.renderBreadCrumb"));
+        extensionLessUrls = Boolean.parseBoolean(getProperty("admin.extensionLessUrls"));
         rippleElements = getProperty("admin.rippleElements");
         enableSlideMenu =  Boolean.parseBoolean(getProperty("admin.enableSlideMenu"));
         skin = getProperty("admin.skin");
@@ -168,6 +170,14 @@ public class AdminConfig implements Serializable {
 
     public void setRenderBreadCrumb(boolean renderBreadCrumb) {
         this.renderBreadCrumb = renderBreadCrumb;
+    }
+
+    public boolean isExtensionLessUrls() {
+        return extensionLessUrls;
+    }
+
+    public void setExtensionLessUrls(boolean extensionLessUrls) {
+        this.extensionLessUrls = extensionLessUrls;
     }
 
     public String getRippleElements() {

--- a/src/main/resources/config/admin-config.properties
+++ b/src/main/resources/config/admin-config.properties
@@ -7,6 +7,7 @@ admin.renderMessages=true
 admin.renderAjaxStatus=true
 admin.disableFilter=false
 admin.renderBreadCrumb=true
+admin.extensionLessUrls=false
 admin.enableSlideMenu=true
 admin.enableRipple=true
 admin.skin=skin-blue


### PR DESCRIPTION
This fixes #46 by adding a new configuration `extensionLessUrls` (defaulting to `false`), that will strip the suffix from breadcrumb navigation when enabled.

The configuration is named `extensionLessUrls` and not mentioning `breadcrumb` in the same as it could be used anywhere else when generating links from the JSF viewId.