### PR TITLE
Use p:autoUpdate instead of autoUpdate attribute for p:messages

### DIFF
--- a/src/main/resources/META-INF/resources/admin-top.xhtml
+++ b/src/main/resources/META-INF/resources/admin-top.xhtml
@@ -156,11 +156,15 @@
                         <ui:fragment rendered="#{adminConfig.renderMessages}">
                             <div class="row">
                                 <div class="col-sm-12">
-                                    <p:messages id="messages" closable="true" globalOnly="true" autoUpdate="true"
-                                                showDetail="true" severity="error,fatal" escape="false"/>
+                                    <p:messages id="messages" closable="true" globalOnly="true"
+                                                showDetail="true" severity="error,fatal" escape="false">
+                                        <p:autoUpdate/>
+                                    </p:messages>
                                     <!-- we need two messages because info-messages are hidden by javascript  -->
-                                    <p:messages id="info-messages" closable="true" autoUpdate="true" showDetail="true"
-                                                severity="info,warn" escape="false"/>
+                                    <p:messages id="info-messages" closable="true" showDetail="true"
+                                                severity="info,warn" escape="false">
+                                        <p:autoUpdate/>
+                                    </p:messages>
                                     <p:tooltip/> <!-- exception messages with type tooltip -->
                                 </div>
                             </div>

--- a/src/main/resources/META-INF/resources/admin.xhtml
+++ b/src/main/resources/META-INF/resources/admin.xhtml
@@ -104,11 +104,15 @@
                     <ui:fragment rendered="#{adminConfig.renderMessages}">
                         <div class="row">
                             <div class="col-sm-12">
-                                <p:messages id="messages" closable="true" globalOnly="true" autoUpdate="true"
-                                            showDetail="true" severity="error,fatal" escape="false"/>
+                                <p:messages id="messages" closable="true" globalOnly="true"
+                                            showDetail="true" severity="error,fatal" escape="false">
+                                    <p:autoUpdate/>
+                                </p:messages>
                                 <!-- we need two messages because info-messages are hidden by javascript  -->
-                                <p:messages id="info-messages" closable="true" autoUpdate="true" showDetail="true"
-                                            severity="info,warn" escape="false"/>
+                                <p:messages id="info-messages" closable="true" showDetail="true"
+                                            severity="info,warn" escape="false">
+                                    <p:autoUpdate/>
+                                </p:messages>
                                 <p:tooltip/> <!-- exception messages with type tooltip -->
                             </div>
                         </div>


### PR DESCRIPTION
Fixes #48 by using the `p:autoUpdate` tag instead of using `autoUpdate` attribute of `p:messages` tag.