### PR TITLE
Add new config for setting page title and breadcrumb title.

### DIFF
--- a/src/main/java/com/github/adminfaces/template/bean/BreadCrumbMB.java
+++ b/src/main/java/com/github/adminfaces/template/bean/BreadCrumbMB.java
@@ -37,11 +37,13 @@ public class BreadCrumbMB implements Serializable {
           maxSize = adminConfig.getBreadCrumbMaxSize();
     }
 
-    public void add(String link, String title, Boolean clear){
+    public void add(String link, String title, Boolean clear, Boolean shouldAdd){
         if(clear != null && clear){
             breadCrumbs.clear();
         }
-        add(new BreadCrumb(link,title));
+        if(shouldAdd) {
+            add(new BreadCrumb(link, title));
+        }
     }
 
     public void add(BreadCrumb breadCrumb){

--- a/src/main/resources/META-INF/resources/admin.xhtml
+++ b/src/main/resources/META-INF/resources/admin.xhtml
@@ -71,10 +71,13 @@
             </aside>
             <!-- content -->
             <div id="content" class="content-wrapper">
+                <adm:breadcrumb title="#{title}" rendered="#{not empty title}"/>
                 <ui:insert name="content-wrapper"/>
                 <section class="content-header">
                     <h1>
-                        <ui:insert name="title"/>
+                        <ui:insert name="title">
+                            <h:outputText value="#{title}" rendered="#{not empty title}"/>
+                        </ui:insert>
                         <small><ui:insert name="description"/></small>
                     </h1>
                     <ui:fragment rendered="#{(adminConfig.renderBreadCrumb) and (empty renderBreadCrumb or renderBreadCrumb eq 'true') }">

--- a/src/main/resources/META-INF/resources/admin/breadcrumb.xhtml
+++ b/src/main/resources/META-INF/resources/admin/breadcrumb.xhtml
@@ -11,7 +11,7 @@
     </cc:interface>
 
     <cc:implementation>
-        <f:event type="preRenderView" listener="#{breadCrumbMB.add(cc.attrs.link, cc.attrs.title, cc.attrs.clear)}"/>
+        <f:event type="preRenderView" listener="#{breadCrumbMB.add(cc.attrs.link, cc.attrs.title, cc.attrs.clear, cc.rendered)}"/>
     </cc:implementation>
 
 </ui:composition>


### PR DESCRIPTION
Use `<ui:param name="title">` for both page title and breadcrumb title. The param must be set in global page scope so that it is available inside the content `<div>`.

Fixes #50