### PR TITLE
admin-config.properties should be optional

### DIFF
--- a/src/main/java/com/github/adminfaces/template/config/AdminConfig.java
+++ b/src/main/java/com/github/adminfaces/template/config/AdminConfig.java
@@ -62,7 +62,9 @@ public class AdminConfig implements Serializable {
         adminConfigFile = new Properties();
         userConfigFile = new Properties();
         try (InputStream is = cl.getResourceAsStream(("admin-config.properties"))) {
-            userConfigFile.load(is);
+			if (is != null) {
+				userConfigFile.load(is);
+			}
         } catch (IOException ex) {
             log.log(Level.WARNING,"Could not load user defined admin template properties. Falling back to default properties.");
         }


### PR DESCRIPTION
checking if inputstream of user admin-config.properties is null before loading it.

If admin-config.properties is missing at resources root folder, AdminFaces template does not start.