### PR TITLE
Load template from resources too.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -304,8 +304,8 @@ The user can change layout modes via <<Control Sidebar, control sidebar>> but to
 
 As a *convention over configuration* LayoutMB will load templates from the following locations:
 
-* `webapp/WEB-INF/templates/template.xhtml` for the `left menu` based template 
-* `webapp/WEB-INF/templates/template-top.xhtml` for horizontal menu layout.
+* `webapp/WEB-INF/templates/template.xhtml` and `resources/META-INF/resources/templates/template.xhtml` for the `left menu` based template 
+* `webapp/WEB-INF/templates/template-top.xhtml` and `resources/META-INF/resources/templates/template-top.xhtml` for horizontal menu layout.
 
 NOTE: If you don't provide a <<Application template>> then built in `admin.xhtml` and `admin-top.xhtml` templates will be used. 
 

--- a/src/main/java/com/github/adminfaces/template/bean/LayoutMB.java
+++ b/src/main/java/com/github/adminfaces/template/bean/LayoutMB.java
@@ -26,6 +26,8 @@ public class LayoutMB implements Serializable {
     private static final String WEBAPP_PREFFIX = "/WEB-INF"; // template webapp preffix path
 
     private String template;
+	private String templatePath;
+	private String templateTopPath;
     private Boolean leftMenuTemplate; 
     private Boolean fixedLayout;
     private Boolean boxedLayout;
@@ -39,7 +41,10 @@ public class LayoutMB implements Serializable {
 
     @PostConstruct
     public void init() {
-        if (adminConfig.isLeftMenuTemplate()) {
+		this.templatePath = findTemplate(APP_TEMPLATE_PATH, DEFAULT_TEMPLATE);
+		this.templateTopPath = findTemplate(APP_TEMPLATE_TOP_PATH, TEMPLATE_TOP);
+
+		if (adminConfig.isLeftMenuTemplate()) {
             setDefaultTemplate();
         } else {
             setTemplateTop();
@@ -63,18 +68,12 @@ public class LayoutMB implements Serializable {
     }
 
     public void setTemplateTop() {
-		template = findAppTemplate(APP_TEMPLATE_TOP_PATH);
-		if (template == null) {
-            template = TEMPLATE_TOP;
-        }
+		template = templateTopPath;
         leftMenuTemplate = false;
-    }
-
+	}
+	
     public void setDefaultTemplate() {
-		template = findAppTemplate(APP_TEMPLATE_PATH);
-        if (template == null) {
-            template = DEFAULT_TEMPLATE;
-        }
+		template = templatePath;
         leftMenuTemplate = true;
     }
 
@@ -180,12 +179,14 @@ public class LayoutMB implements Serializable {
         }		
 	}
 	
-    private String findAppTemplate(String appTemplatePath) {
-		String result = null;
+    private String findTemplate(String appTemplatePath, String bundledPath) {
+		String result;
 		if (templateExists(WEBAPP_PREFFIX + appTemplatePath)) {
 			result = WEBAPP_PREFFIX + appTemplatePath;
 		} else if (templateExists(RESOURCES_PREFFIX + appTemplatePath)) {
 			result = RESOURCES_PREFFIX + appTemplatePath;
+		} else {
+			result = bundledPath;
 		}
         return result;
     }

--- a/src/main/java/com/github/adminfaces/template/bean/LayoutMB.java
+++ b/src/main/java/com/github/adminfaces/template/bean/LayoutMB.java
@@ -20,11 +20,12 @@ public class LayoutMB implements Serializable {
     private static final Logger LOG = Logger.getLogger(LayoutMB.class.getName());
     private static final String DEFAULT_TEMPLATE = "/admin.xhtml"; //template bundled in admin-template 
     private static final String TEMPLATE_TOP = "/admin-top.xhtml"; //template bundled in admin-template 
-    private static final String APP_TEMPLATE_PATH = "/WEB-INF/templates/template.xhtml"; // application template (left menu)
-    private static final String APP_TEMPLATE_TOP_PATH = "/WEB-INF/templates/template-top.xhtml"; //application template (top menu)
+    private static final String APP_TEMPLATE_PATH = "/templates/template.xhtml"; // application template (left menu)
+    private static final String APP_TEMPLATE_TOP_PATH = "/templates/template-top.xhtml"; //application template (top menu)
+    private static final String RESOURCES_PREFFIX = ""; // template resources preffix path
+    private static final String WEBAPP_PREFFIX = "/WEB-INF"; // template webapp preffix path
 
     private String template;
-    private Boolean appTemplateExists;
     private Boolean leftMenuTemplate; 
     private Boolean fixedLayout;
     private Boolean boxedLayout;
@@ -62,19 +63,16 @@ public class LayoutMB implements Serializable {
     }
 
     public void setTemplateTop() {
-        if (appTemplateExists()) {
-            template = APP_TEMPLATE_TOP_PATH;
-            
-        } else {
+		template = findAppTemplate(APP_TEMPLATE_TOP_PATH);
+		if (template == null) {
             template = TEMPLATE_TOP;
         }
         leftMenuTemplate = false;
     }
 
     public void setDefaultTemplate() {
-        if (appTemplateExists()) {
-            template = APP_TEMPLATE_PATH;
-        } else {
+		template = findAppTemplate(APP_TEMPLATE_PATH);
+        if (template == null) {
             template = DEFAULT_TEMPLATE;
         }
         leftMenuTemplate = true;
@@ -173,18 +171,22 @@ public class LayoutMB implements Serializable {
         return template != null && (template.endsWith("template.xhtml") || template.equals("admin.xhtml"));
     }
 
-    private boolean appTemplateExists() {
-        if (appTemplateExists != null) {
-            return appTemplateExists;
-        }
+	private boolean templateExists(String templateName) {
         try {
-            appTemplateExists = Faces.getExternalContext().getResourceAsStream(APP_TEMPLATE_PATH) != null;
+            return Faces.getExternalContext().getResourceAsStream(templateName) != null;
         } catch (Exception e) {
             LOG.warning(String.format("Could not find application defined template in path '%s' due to following error: %s. Falling back to default admin template. See application template documentation for more details: https://github.com/adminfaces/admin-template#application-template", APP_TEMPLATE_PATH, e.getMessage()));
-            appTemplateExists = false;
-        }
-
-        return appTemplateExists;
+            return false;
+        }		
+	}
+	
+    private String findAppTemplate(String appTemplatePath) {
+		String result = null;
+		if (templateExists(WEBAPP_PREFFIX + appTemplatePath)) {
+			result = WEBAPP_PREFFIX + appTemplatePath;
+		} else if (templateExists(RESOURCES_PREFFIX + appTemplatePath)) {
+			result = RESOURCES_PREFFIX + appTemplatePath;
+		}
+        return result;
     }
-
 }


### PR DESCRIPTION
Today, `LayoutMB` loads app template from `webapp/WEB-INF/templates` folder.
JSF can load templates from `resources/META-INF/resources` folder too. Using `Spring Boot Jar packaging`, jsf artifacts sould be stored in this folder because there is no `webapp/WEB-INF/templates` folder.
This PR allows `LayoutMB` to load templates from `resources folder` if it is not found at `WEB-INF folder`.