### PR TITLE
Avoid blind indexof in search of dot; If using provided url avoids fa…

### DIFF
--- a/src/main/java/com/github/adminfaces/template/bean/BreadCrumbMB.java
+++ b/src/main/java/com/github/adminfaces/template/bean/BreadCrumbMB.java
@@ -62,7 +62,10 @@ public class BreadCrumbMB implements Serializable {
         }
 
         if(link != null && adminConfig.isExtensionLessUrls()) {
-            link = link.substring(0, link.lastIndexOf("."));
+            int idx = link.lastIndexOf(".");
+            if (idx != -1) {
+                link = link.substring(0, idx);
+            }
         } else if(link != null && !link.contains(".")) {
             link = link + "." + adminConfig.getPageSufix();
         }


### PR DESCRIPTION
Avoid blind indexof in search of dot; If using provided url avoids failure on generating the url to include in breadcrumb