### PR TITLE
Fixes multi-level menu

### DIFF
--- a/src/main/resources/META-INF/resources/js/admintemplate.js
+++ b/src/main/resources/META-INF/resources/js/admintemplate.js
@@ -52,8 +52,11 @@ function activateMenu(url, activated) {
         var currentPage = stripTrailingSlash($(this).attr('href'));
         //console.log("sub-activePage:" + activePage +" sub-currentPage:" + currentPage);
         if (activePage == currentPage) {
-            $(this).parent().addClass('active');
-            $(this).parent().parent().parent().addClass('active');
+        	$(this).parentsUntil( "ul.sidebar-menu", "li.treeview" ).each(function () {
+                $(this).addClass('active');
+             });
+            //$(this).parent().addClass('active');
+            //$(this).parent().parent().parent().addClass('active');
             activated = true;
         }
     });


### PR DESCRIPTION
When using multi-level admin-lte menus, the nested menu don't open automatically - Only the first level. With this, the ancestor tree is scanned and all levels up are actively automatically