### PR TITLE
upgrade to Primefaces 8, support skipDetailIfEqualsSummary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
-            <version>7.0</version>
+            <version>8.0</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces</groupId>

--- a/src/main/java/com/github/adminfaces/template/config/AdminConfig.java
+++ b/src/main/java/com/github/adminfaces/template/config/AdminConfig.java
@@ -36,6 +36,7 @@ public class AdminConfig implements Serializable {
     private String templatePath;
     private Integer breadCrumbMaxSize;
     private boolean renderMessages;
+    private boolean skipMessageDetailIfEqualsSummary;
     private boolean renderAjaxStatus;
     private boolean disableFilter;
     private boolean enableRipple;
@@ -93,6 +94,7 @@ public class AdminConfig implements Serializable {
         templatePath = getProperty("admin.templatePath");
         breadCrumbMaxSize = Integer.parseInt(getProperty("admin.breadcrumbSize"));
         renderMessages = Boolean.parseBoolean(getProperty("admin.renderMessages"));
+        skipMessageDetailIfEqualsSummary = Boolean.parseBoolean(getProperty("admin.skipMessageDetailIfEqualsSummary"));
         renderAjaxStatus = Boolean.parseBoolean(getProperty("admin.renderAjaxStatus"));
         disableFilter = Boolean.parseBoolean(getProperty("admin.disableFilter"));
         enableRipple = Boolean.parseBoolean(getProperty("admin.enableRipple"));
@@ -295,6 +297,14 @@ public class AdminConfig implements Serializable {
 
     public void setRenderMessages(boolean renderMessages) {
         this.renderMessages = renderMessages;
+    }
+
+    public boolean isSkipMessageDetailIfEqualsSummary() {
+        return skipMessageDetailIfEqualsSummary;
+    }
+
+    public void setSkipMessageDetailIfEqualsSummary(boolean skipMessageDetailIfEqualsSummary) {
+        this.skipMessageDetailIfEqualsSummary = skipMessageDetailIfEqualsSummary;
     }
 
     public boolean isRenderAjaxStatus() {

--- a/src/main/resources/META-INF/resources/admin-base.xhtml
+++ b/src/main/resources/META-INF/resources/admin-base.xhtml
@@ -116,12 +116,14 @@
                     <div class="row">
                         <div class="col-sm-12">
                             <p:messages id="messages" closable="true" globalOnly="true" autoUpdate="true"
-                                        showDetail="true" severity="error,fatal" escape="false">
+                                        showDetail="true" severity="error,fatal" escape="false"
+                                        skipDetailIfEqualsSummary="#{adminConfig.skipMessageDetailIfEqualsSummary}">
                                 <p:autoUpdate/>
                             </p:messages>
                                 <!-- we need two messages because info-messages are automatically hidden via javascript  -->
                             <p:messages id="info-messages" closable="true" showDetail="true" autoUpdate="true"
-                                        severity="info,warn" escape="false">
+                                        severity="info,warn" escape="false"
+                                        skipDetailIfEqualsSummary="#{adminConfig.skipMessageDetailIfEqualsSummary}">
                                 <p:autoUpdate/>
                             </p:messages>
                             <p:tooltip/> <!-- exception messages with type tooltip -->

--- a/src/main/resources/config/admin-config.properties
+++ b/src/main/resources/config/admin-config.properties
@@ -3,6 +3,7 @@ admin.indexPage=index.xhtml
 admin.dateFormat=
 admin.breadcrumbSize=5
 admin.renderMessages=true
+admin.skipMessageDetailIfEqualsSummary=true
 admin.renderAjaxStatus=true
 admin.disableFilter=false
 admin.renderBreadCrumb=true


### PR DESCRIPTION
PrimeFaces 8 finally supports p:messages skipDetailIfEqualsSummary=true to avoid message summary is displayed twice